### PR TITLE
fix passing of optional state value

### DIFF
--- a/lib/ueberauth/strategy/zoom.ex
+++ b/lib/ueberauth/strategy/zoom.ex
@@ -24,7 +24,7 @@ defmodule Ueberauth.Strategy.Zoom do
   end
 
   defp put_state_option(opts, %{params: %{"state" => state}}) do
-    Keyword.put(opts, :state, state)
+    Keyword.put(opts, :params, %{"state" => state})
   end
 
   defp put_state_option(opts, _), do: opts

--- a/test/ueberauth/strategy/zoom_test.exs
+++ b/test/ueberauth/strategy/zoom_test.exs
@@ -42,5 +42,27 @@ defmodule Ueberauth.Strategy.ZoomTest do
                status: 302
              } = conn
     end
+
+    test "passes the state value as a param if specified" do
+      authorize_url = "https://zoomapi.test"
+      optional_state = %{"state" => "state-value"}
+
+      expect(OAuthMock, :authorize_url!, fn params, opts ->
+        assert params == []
+
+        assert opts == [
+                 {:params, optional_state},
+                 {:redirect_uri, "http://www.example.com/auth/zoom/callback"}
+               ]
+
+        authorize_url
+      end)
+
+      conn =
+        conn(:get, "/", %{state: "state-value"})
+        |> Ueberauth.run_request(:zoom, @provider_config)
+
+      assert %Plug.Conn{params: ^optional_state} = conn
+    end
   end
 end


### PR DESCRIPTION
The current implementation doesn't pass the optional state value all the way to Zoom. It gets dropped in the OAuth2 library, specifically [here](https://github.com/scrogson/oauth2/blob/1d09592bd06e2e4cb6f8dd5c98af4371a3eef7a5/lib/oauth2/client.ex#L139), because `state` is not an expected key and instead it expects `params` to exist in a `params` map. 

I added a test, but it is less than ideal, because the OAauth2 lib is mocked out in the test it doesn't really exhibit the failure.  

The fix I added works for my own application, but I don't know enough about OAuth or ueberauth to know if it has any unintended side effects. 